### PR TITLE
Fix a problem with rwd theme like in #31

### DIFF
--- a/app/code/community/Easylife/Switcher/sql/easylife_switcher_setup/upgrade-0.0.1-1.0.1.php
+++ b/app/code/community/Easylife/Switcher/sql/easylife_switcher_setup/upgrade-0.0.1-1.0.1.php
@@ -31,7 +31,7 @@ if (version_compare(Mage::getVersion(), $checkVersion, '>=')) {
 ProductMediaManager.createZoom(jQuery(\'#image-main\'));',
         'easylife_switcher/settings/image_selector' => '$(\'image-main\')',
         'easylife_switcher/settings/media_change_callback' => 'ProductMediaManager.destroyZoom();
-ProductMediaManager.createZoom(jQuery(\'#image-main\'));',
+ProductMediaManager.createZoom(jQuery(\'#image-main\'));ProductMediaManager.init();',
         'easylife_switcher/settings/media_selector' => '$$(\'.product-view .product-img-box\')[0]',
     );
     foreach ($configSettings as $path=>$value) {


### PR DESCRIPTION
The "Js Callback after media change" was not really working with the image switcher in rwd theme, because without a new .init() call the listening events where not created. In #31 you say you just want to be "default" compatible but with the already beeing in place addition of ProductMediaManager i thought this might be helpfull.
