### PR TITLE
Skip attributes not selected for swatch replacement

### DIFF
--- a/js/easylife_switcher/product.js
+++ b/js/easylife_switcher/product.js
@@ -118,6 +118,12 @@ Easylife.Switcher = Class.create(Product.Config, {
     transformDropdown: function(selectid){
         var that = this;
         var attributeId = $(selectid).id.replace(/[a-z]*/, '');
+        
+        //skip attributes not configured to replace with swatches
+        if(!this.config.switch_attributes[attributeId]){
+            return;
+        }
+        
         var selectname = $(selectid).name;
         var newId = $(selectid).id +'_switchers';
         //remove previous labels


### PR DESCRIPTION
The skip_attributes property is never used but in the module config it seems that it's meant to skip any attribute not selected.
