### PR TITLE
Added current store parameter

### DIFF
--- a/app/code/community/Easylife/Switcher/Helper/Data.php
+++ b/app/code/community/Easylife/Switcher/Helper/Data.php
@@ -38,6 +38,6 @@ class Easylife_Switcher_Helper_Data extends Mage_Core_Helper_Abstract {
      * @author Marius Strajeru <marius.strajeru@gmail.com>
      */
     public function isEnabled(){
-        return Mage::getStoreConfigFlag(self::XML_ENABLED_PATH);
+        return Mage::getStoreConfigFlag(self::XML_ENABLED_PATH, Mage::app()->getRequest()->getParam('store'));
     }
 }


### PR DESCRIPTION
Otherwise, if the module is disable by default, but enabled for a specific store, the "Default simple product" column won't appear in admin as the call will be `Mage::getStoreConfigFlag(self::XML_ENABLED_PATH, null)` return the default configuration value, not the one for the store (when one uses the store dropdown in admin).
