### PR TITLE
Fixes a Bug where the configurable product has more than 2 options

### DIFF
--- a/js/easylife_switcher/product.js
+++ b/js/easylife_switcher/product.js
@@ -300,6 +300,7 @@ Easylife.Switcher = Class.create(Product.Config, {
                 $(element.nextSetting).value = this.currentValues[nextSettingId];
                 if (!$(element.nextSetting).value) {
                     delete this.currentValues[nextSettingId];
+                    $(element.nextSetting).selectedIndex = 0; // value not set selected index ist probadly also wrong
                 }
                 var label = $('attribute' + nextSettingId + '_' + this.currentValues[nextSettingId]);
                 if (label) {
@@ -373,6 +374,9 @@ Easylife.Switcher = Class.create(Product.Config, {
      * @param element
      */
     configureElement: function($super, element){
+        if (element.selectedIndex < 0) {
+            element.selectedIndex = 0; // element.selectedIndex = -1 breaks everything
+        }
         $super(element);
         var attributeId = $(element).id.replace(/[a-z]*/, '');
         var reset = false;

--- a/js/easylife_switcher/product.js
+++ b/js/easylife_switcher/product.js
@@ -314,9 +314,10 @@ Easylife.Switcher = Class.create(Product.Config, {
         //recalculate current values
         this.currentValues = {};
         for (var i=0; i<this.settings.length;i++){
-            if ($(this.settings[i]).value) {
+            var optionValue = $(this.settings[i]).value;
+            if (optionValue && this.getConfigValue(this.config, 'chooseText', '') != optionValue) {
                 var id = $(this.settings[i]).id.replace(/[a-z]*/, '');
-                this.currentValues[id] = $(this.settings[i]).value;
+                this.currentValues[id] = optionValue;
             }
         }
     },


### PR DESCRIPTION
Hi, 

thanks for this awesome module. I encountered one tiny Problem: 

The option value of a non selected value is sometimes `"Choose Option..."` (label of the first option), which produces an error in your code (`TypeError: Cannot read property 'config' of undefined`). I cloud only reproduce this error on a configurable product with more than two options.  

It could also fix Issue #15.
