### PR TITLE
add support for change_media_attributes adminhtml config

### DIFF
--- a/app/code/community/Easylife/Switcher/Block/Catalog/Product/View/Type/Configurable/Config.php
+++ b/app/code/community/Easylife/Switcher/Block/Catalog/Product/View/Type/Configurable/Config.php
@@ -265,6 +265,7 @@ class Easylife_Switcher_Block_Catalog_Product_View_Type_Configurable_Config exte
 
         $config['switch_images']            = $this->getSwitchImages();
         $config['switch_media']             = $this->getSwitchMedia();
+        $config['change_media_attributes']  = Mage::getStoreConfig(self::XML_CHANGE_MEDIA_PATH);
         $config['switch_media_selector']    = Mage::getStoreConfig(self::XML_MEDIA_SELECTOR);
         $config['switch_media_callback']    = Mage::getStoreConfig(self::XML_MEDIA_CALLBACK_PATH);
         $config['allow_no_stock_select']    = $this->getAllowNoStockSelect();

--- a/js/easylife_switcher/product.js
+++ b/js/easylife_switcher/product.js
@@ -377,6 +377,15 @@ Easylife.Switcher = Class.create(Product.Config, {
         var reset = false;
         this.keepSelection(element);
         var value = $(element).value;
+
+        //if the selected attribute does not match the one of the change_media_attributes config
+        //stop it here
+        var changeMediaAttr = this.getConfigValue(this.config, 'change_media_attributes', false);
+        var currCodeAttr = this.config.attributes[attributeId].code;
+        if (currCodeAttr.indexOf(changeMediaAttr.split(',')) == -1) {
+            return ;
+        }
+
         //var options = this.config.attributes[attributeId].options;
         //if we should not switch anything stop it here
         var switchType = this.getConfigValue(this.config, 'switch_image_type', 0);


### PR DESCRIPTION
When you select an attribute on the product page, only the media gallery change if the attribute was selected in the system > configuration.